### PR TITLE
Failed Request Returns default Instead of Throwing

### DIFF
--- a/DiscoveryService/AsyncDiscoveryServiceProxy.cs
+++ b/DiscoveryService/AsyncDiscoveryServiceProxy.cs
@@ -151,6 +151,7 @@ namespace Microsoft.Xrm.Sdk.Client.Async
             catch
             {
                 forceClose = true;
+                throw;
             }
             finally
             {

--- a/OrganizationService/AsyncOrganizationServiceProxy.cs
+++ b/OrganizationService/AsyncOrganizationServiceProxy.cs
@@ -675,6 +675,7 @@ namespace Microsoft.Xrm.Sdk.Client.Async
                 }
             } catch {
                 forceClose = true;
+                throw;
             } finally {
                 this.CloseChannel(forceClose);
             }


### PR DESCRIPTION
Unknown exceptions cause the process to return default(T) instead of throwing. For example, the following code will generate a FaultException and return a null response. 

```
var query = new QueryExpression("account");
query.Criteria.AddCondition("primarycontactid", ConditionOperator.Equal, new EntityReference("account", Guid.NewGuid()));
var response = await service.RetrieveMultipleAsync(query);
// response is null. 
```

This could be especially painful to troubleshoot for requests that callers might not normally check the response for like a Create or WinOpportunityRequest. 